### PR TITLE
minor floating mode fix for setborderpx patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Refer to [https://dwm.suckless.org/](https://dwm.suckless.org/) for details on t
    - [sendmon_keepfocus](https://github.com/bakkeby/patches/wiki/sendmon_keepfocus/)
       - minor patch that allow clients to keep focus when being sent to another monitor
 
-   - [setborderpx](https://dwm.suckless.org/patches/statuspadding/)
+   - [setborderpx](https://dwm.suckless.org/patches/setborderpx/)
       - this patch allows border pixels to be changed during runtime
 
    - [shiftview](https://github.com/chau-bao-long/dotfiles/blob/master/suckless/dwm/shiftview.diff)

--- a/patch/setborderpx.c
+++ b/patch/setborderpx.c
@@ -17,11 +17,12 @@ setborderpx(const Arg *arg)
 			c->bw = selmon->borderpx = 0;
 		else
 			c->bw = selmon->borderpx;
-
 		if (c->isfloating || !selmon->lt[selmon->sellt]->arrange)
 		{
-			if (arg->i != 0)
+			if (arg->i != 0 && prev_borderpx + arg->i >= 0)
 				resize(c, c->x, c->y, c->w-(arg->i*2), c->h-(arg->i*2), 0);
+			else if (arg->i != 0)
+				resizeclient(c, c->x, c->y, c->w, c->h);
 			else if (prev_borderpx > borderpx)
 				resize(c, c->x, c->y, c->w + 2*(prev_borderpx - borderpx), c->h + 2*(prev_borderpx - borderpx), 0);
 			else if (prev_borderpx < borderpx)


### PR DESCRIPTION
Floating window borders should resize now the same way as tiled window borders.