### PR TITLE
added pertag-perseltag

### DIFF
--- a/patches.def.h
+++ b/patches.def.h
@@ -683,6 +683,11 @@
  */
 #define PERTAG_PATCH 0
 
+/* This patch allows you to modify nmaster, mfact and layouts
+ * simultaniously on selected tags.
+ */
+#define PERTAG_PERSELTAG_PATCH 0
+
 /* This controls whether or not to also store bar position on a per
  * tag basis, or leave it as one bar per monitor.
  */


### PR DESCRIPTION
I tried to include pertag-perseltag patch from [https://dwm.suckless.org/patches/pertag/dwm-pertag-perseltag-6.2.diff](https://dwm.suckless.org/patches/pertag/dwm-pertag-perseltag-6.2.diff)

It is necessary to enable both PERTAG_PATCH and PERTAG_PERSELTAG to use it. PERTAGBAR_PATCH remains optional.