### PR TITLE
fix warp patch

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -2780,7 +2780,7 @@ restack(Monitor *m)
 		(m->lt[m->sellt]->arrange != &monocle
 		&& !(m->ltaxis[MASTER] == MONOCLE && (abs(m->ltaxis[LAYOUT] == NO_SPLIT || !m->nmaster || n <= m->nmaster))))
 		#elif MONOCLE_LAYOUT
-		m->lt[m->sellt]->arrange == &monocle
+		m->lt[m->sellt]->arrange != &monocle
 		#else
 		!(m->ltaxis[MASTER] == MONOCLE && (abs(m->ltaxis[LAYOUT] == NO_SPLIT || !m->nmaster || n <= m->nmaster)))
 		#endif // FLEXTILE_DELUXE_LAYOUT

--- a/patch/warp.c
+++ b/patch/warp.c
@@ -13,10 +13,10 @@ warp(const Client *c)
 		 y > c->y - c->bw &&
 		 x < c->x + c->w + c->bw*2 &&
 		 y < c->y + c->h + c->bw*2) ||
-		x < c->mon->wx ||
-		x > c->mon->wx + c->mon->ww ||
-		y < c->mon->wy ||
-		y > c->mon->wy + c->mon->wh
+		(x < c->mon->wx &&
+		x > c->mon->wx + c->mon->ww) ||
+		(y < c->mon->wy ||
+		y > c->mon->wy + c->mon->wh)
 	)
 		return;
 


### PR DESCRIPTION
The warp patch is (after this commit still) not working as expected.
This fixes the issue on one monitor, but the mouse does not follow onto a second.

I tried further investigating this by adding system("notify-send")'s everywhere.
To my understanding, this gets called correctly but the if statement of the`warp()` function in `patch/warp.c` returns falsely.

Before commit [8ec80be7565e0b2e80a90ba617788b2d06a23f8d](https://github.com/bakkeby/dwm-flexipatch/commit/8ec80be7565e0b2e80a90ba617788b2d06a23f8d) this worked perfectly.

Unluckily, my C knowledge ends here. So further investigation is needed to fix the second monitor thing.