### PR TITLE
Updated to latest inplacerotate

### DIFF
--- a/patch/inplacerotate.c
+++ b/patch/inplacerotate.c
@@ -1,6 +1,5 @@
 void
-insertclient(Client *item, Client *insertItem, int after)
-{
+insertclient(Client *item, Client *insertItem, int after) {
 	Client *c;
 	if (item == NULL || insertItem == NULL || item == insertItem) return;
 	detach(insertItem);
@@ -20,26 +19,31 @@ insertclient(Client *item, Client *insertItem, int after)
 void
 inplacerotate(const Arg *arg)
 {
-	if (!selmon->sel || (selmon->sel->isfloating && !arg->f)) return;
+	if(!selmon->sel || (selmon->sel->isfloating && !arg->f)) return;
 
 	unsigned int selidx = 0, i = 0;
 	Client *c = NULL, *stail = NULL, *mhead = NULL, *mtail = NULL, *shead = NULL;
 
-	// Shift client
+	// Determine positionings for insertclient
 	for (c = selmon->clients; c; c = c->next) {
 		if (ISVISIBLE(c) && !(c->isfloating)) {
-			if (selmon->sel == c) { selidx = i; }
-			if (i == selmon->nmaster - 1) { mtail = c; }
-			if (i == selmon->nmaster) { shead = c; }
-			if (mhead == NULL) { mhead = c; }
-			stail = c;
-			i++;
+		if (selmon->sel == c) { selidx = i; }
+		if (i == selmon->nmaster - 1) { mtail = c; }
+		if (i == selmon->nmaster) { shead = c; }
+		if (mhead == NULL) { mhead = c; }
+		stail = c;
+		i++;
 		}
 	}
-	if (arg->i < 0 && selidx >= selmon->nmaster) insertclient(stail, shead, 1);
-	if (arg->i > 0 && selidx >= selmon->nmaster) insertclient(shead, stail, 0);
-	if (arg->i < 0 && selidx < selmon->nmaster)  insertclient(mtail, mhead, 1);
-	if (arg->i > 0 && selidx < selmon->nmaster)  insertclient(mhead, mtail, 0);
+
+	// All clients rotate
+	if (arg->i == 2) insertclient(selmon->clients, stail, 0);
+	if (arg->i == -2) insertclient(stail, selmon->clients, 1);
+	// Stack xor master rotate
+	if (arg->i == -1 && selidx >= selmon->nmaster) insertclient(stail, shead, 1);
+	if (arg->i == 1 && selidx >= selmon->nmaster) insertclient(shead, stail, 0);
+	if (arg->i == -1 && selidx < selmon->nmaster)  insertclient(mtail, mhead, 1);
+	if (arg->i == 1 && selidx < selmon->nmaster)  insertclient(mhead, mtail, 0);
 
 	// Restore focus position
 	i = 0;


### PR DESCRIPTION
Updated to the latest inplacerotate patch (https://dwm.suckless.org/patches/inplacerotate/dwm-inplacerotate-6.2.diff), which allows rotating all the clients, if `inplacerotate` is called with `-2/+2`.
