### PR TITLE
update config: reorder rules for WINTYPE base rule

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -404,15 +404,15 @@ static const Rule rules[] = {
 	 *	WM_WINDOW_ROLE(STRING) = role
 	 *	_NET_WM_WINDOW_TYPE(ATOM) = wintype
 	 */
-	RULE(.wintype = WTYPE "DIALOG", .isfloating = 1)
-	RULE(.wintype = WTYPE "UTILITY", .isfloating = 1)
-	RULE(.wintype = WTYPE "TOOLBAR", .isfloating = 1)
-	RULE(.wintype = WTYPE "SPLASH", .isfloating = 1)
 	RULE(.class = "Gimp", .tags = 1 << 4)
 	RULE(.class = "Firefox", .tags = 1 << 7)
 	#if SCRATCHPADS_PATCH
 	RULE(.instance = "spterm", .tags = SPTAG(0), .isfloating = 1)
 	#endif // SCRATCHPADS_PATCH
+	RULE(.wintype = WTYPE "DIALOG", .isfloating = 1)
+	RULE(.wintype = WTYPE "UTILITY", .isfloating = 1)
+	RULE(.wintype = WTYPE "TOOLBAR", .isfloating = 1)
+	RULE(.wintype = WTYPE "SPLASH", .isfloating = 1)
 };
 
 #if MONITOR_RULES_PATCH


### PR DESCRIPTION
i found out that a rule that base on `_NET_WM_WINDOW_TYPE` must be placed at the very end of the rules array to ensure it work as expected, specially if used with the `RULE` macro.
For example *firefox* and it's *PictureInPicture* (`_NET_WM_WINDOW_TYPE_UTILITY`) window, if i define a rule with `wintype = WTYPE "UTILITY"` at the very top and set it as floating window, and then define a rule for `firefox` class and set it to non floating window, the firefox PictureInPicture window will not be floating.