### PR TITLE
Use 'pgrep -o' instead of 'pidof -s' to get the PID of status bar

### DIFF
--- a/patch/bar_dwmblocks.c
+++ b/patch/bar_dwmblocks.c
@@ -18,7 +18,7 @@ getstatusbarpid()
 				return statuspid;
 		}
 	}
-	if (!(fp = popen("pidof -s "STATUSBAR, "r")))
+	if (!(fp = popen("pgrep -o "STATUSBAR, "r")))
 		return -1;
 	fgets(buf, sizeof(buf), fp);
 	pclose(fp);


### PR DESCRIPTION
This is being done to extend compatibility to [`dwmblocks-async`](https://github.com/UtkarshVerma/dwmblocks-async) which creates a subprocess, because of which `pidof -s dwmblocks` returns the PID of the subprocess, instead of the parent, which handles the signals.

Without this PR, `dwmblocks-async` doesn't get click events.

Below is a quick comparison of both commands. The PID of the parent is 21677.

```sh
❯ pidof dwmblocks
21678 21677
❯ pgrep dwmblocks
21677
21678
❯ pidof -s dwmblocks
21678
❯ pgrep -o dwmblocks
21677
```