### PR TITLE
Improve padding logic for the systray patch

### DIFF
--- a/patch/bar_systray.c
+++ b/patch/bar_systray.c
@@ -10,7 +10,14 @@ width_systray(Bar *bar, BarArg *a)
 		return 1;
 	if (showsystray)
 		for (i = systray->icons; i; w += i->w + systrayspacing, i = i->next);
-	return w ? w + lrpad - systrayspacing : 0;
+
+	if (w) {
+		w += lrpad / 2 - systrayspacing;
+		#if !BAR_STATUS_PATCH
+		w += lrpad / 2;
+		#endif // BAR_STATUS_PATCH
+	}
+	return w;
 }
 
 int
@@ -91,7 +98,11 @@ draw_systray(Bar *bar, BarArg *a)
 			i->mon = bar->mon;
 	}
 
-	XMoveResizeWindow(dpy, systray->win, bar->bx + a->x + lrpad / 2, (w ? bar->by + a->y + (a->h - systray->h) / 2: -bar->by - a->y), MAX(w, 1), systray->h);
+	unsigned int xpos = bar->bx + a->x + lrpad / 2;
+	#if BAR_STATUS_PATCH
+	xpos -= lrpad / 2;
+	#endif // BAR_STATUS_PATCH
+	XMoveResizeWindow(dpy, systray->win, xpos, (w ? bar->by + a->y + (a->h - systray->h) / 2: -bar->by - a->y), MAX(w, 1), systray->h);
 	return w;
 }
 


### PR DESCRIPTION
When the systray patch is enabled, there is excess padding between the status text and the systray. This PR hopes to fix that.

One thing I couldn't manage was to handle the edge case of an empty statusbar. As I don't know how to get the width of the status bar, I couldn't implement that logic.