### PR TITLE
Add preserve clients patch

### DIFF
--- a/patch/include.c
+++ b/patch/include.c
@@ -313,6 +313,9 @@
 #if DRAGMFACT_PATCH
 #include "dragmfact.c"
 #endif
+#if PRESERVECLIENTS_PATCH
+#include "preserveclients.c"
+#endif
 /* Layouts */
 #if BSTACK_LAYOUT || BSTACKHORIZ_LAYOUT || CENTEREDMASTER_LAYOUT || CENTEREDFLOATINGMASTER_LAYOUT || COLUMNS_LAYOUT || DECK_LAYOUT || TILE_LAYOUT
 #include "layout_facts.c"

--- a/patch/include.h
+++ b/patch/include.h
@@ -309,6 +309,9 @@
 #if XRDB_PATCH && !BAR_VTCOLORS_PATCH
 #include "xrdb.h"
 #endif
+#if PRESERVECLIENTS_PATCH
+#include "preserveclients.h"
+#endif
 /* Layouts */
 #if BSTACK_LAYOUT
 #include "layout_bstack.h"

--- a/patch/preserveclients.c
+++ b/patch/preserveclients.c
@@ -1,0 +1,8 @@
+void
+setclienttagprop(Client *c)
+{
+	long data[] = { (long) c->tags, (long) c->mon->num };
+	XChangeProperty(dpy, c->win, netatom[NetClientInfo], XA_CARDINAL, 32,
+		PropModeReplace, (unsigned char *) data, 2);
+}
+

--- a/patch/preserveclients.h
+++ b/patch/preserveclients.h
@@ -1,0 +1,2 @@
+static void setclienttagprop(Client *c);
+

--- a/patches.def.h
+++ b/patches.def.h
@@ -1255,6 +1255,12 @@
  */
 #define ZOOMSWAP_PATCH 0
 
+/* Allows clients to be preserved when dwm is renewed.
+ * This patch can be used with restartsig patch to make restarting dwm on fly efficient.
+ * https://lists.suckless.org/hackers/2205/18344.html
+ */
+#define PRESERVECLIENTS_PATCH 0
+
 /**
  * Layouts
  */
@@ -1335,3 +1341,4 @@
  * This can be optionally disabled in favour of other layouts.
  */
 #define MONOCLE_LAYOUT 1
+


### PR DESCRIPTION
Using this patch and restartsig, dwm will be putting clients on their old tags, it's more minimal than the other solutions that I've saw. (including your personal dwm builds: dawn, dusk)

I tested this commit on original dwm-flexipatch and worked find. But not really sure if other patches would break it...

shamelessly taken from:
https://lists.suckless.org/hackers/2205/18344.html