### PR TITLE
Don't autostart if dwm is restarting through the restartsig patch

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -5135,7 +5135,10 @@ main(int argc, char *argv[])
 	loadxrdb();
 	#endif // XRDB_PATCH && !BAR_VTCOLORS_PATCH
 	#if COOL_AUTOSTART_PATCH
-	autostart_exec();
+    #if RESTARTSIG_PATCH
+    if (!restart)
+    #endif // RESTARTSIG_PATCH
+    autostart_exec();
 	#endif // COOL_AUTOSTART_PATCH
 	setup();
 #ifdef __OpenBSD__
@@ -5148,7 +5151,10 @@ main(int argc, char *argv[])
 #endif /* __OpenBSD__ */
 	scan();
 	#if AUTOSTART_PATCH
-	runautostart();
+    #if RESTARTSIG_PATCH
+    if (!restart)
+    #endif // RESTARTSIG_PATCH
+    runautostart();
 	#endif
 	run();
 	cleanup();


### PR DESCRIPTION
Depending on who you ask, this may be an issue or not but this PR as the title says simply makes sure dwm isn't restarting before autostarting.

It *is* an unusual thing to do but for example if restartsig is paired with the fsignal or dwmc patches and the autostart contains a signal to restart dwm, dwm will keep restarting over and over again.

Most people probably (definitely) don't do this but there may be more cases where this can be an issue. The cool autostart patch *should* already kill any old processes before starting new ones but if it doesn't (and for the regular autostart patch), this should also make sure you don't have multiple processes running as a result of restarting dwm.

I am not entirely sure if this behavior is going to be better than how it is right now, but I implemented it into my own build and it seems to work fine.

Let me know if there are any issues with this :)