### PR TITLE
Add swallow/window icon compatibility

### DIFF
--- a/patch/swallow.c
+++ b/patch/swallow.c
@@ -37,7 +37,7 @@ swallow(Client *p, Client *c)
 	XChangeProperty(dpy, c->win, netatom[NetClientList], XA_WINDOW, 32, PropModeReplace,
 		(unsigned char *) &(p->win), 1);
 
-   	#if BAR_WINICON_PATCH
+    #if BAR_WINICON_PATCH
     updateicon(p);
     #endif
 	updatetitle(p);
@@ -73,7 +73,7 @@ unswallow(Client *c)
 
 	/* unfullscreen the client */
 	setfullscreen(c, 0);
-   	#if BAR_WINICON_PATCH
+    #if BAR_WINICON_PATCH
     updateicon(c);
     #endif
 	updatetitle(c);

--- a/patch/swallow.c
+++ b/patch/swallow.c
@@ -37,6 +37,9 @@ swallow(Client *p, Client *c)
 	XChangeProperty(dpy, c->win, netatom[NetClientList], XA_WINDOW, 32, PropModeReplace,
 		(unsigned char *) &(p->win), 1);
 
+   	#if BAR_WINICON_PATCH
+    updateicon(p);
+    #endif
 	updatetitle(p);
 	s = scanner ? c : p;
 	#if BAR_EWMHTAGS_PATCH
@@ -70,6 +73,9 @@ unswallow(Client *c)
 
 	/* unfullscreen the client */
 	setfullscreen(c, 0);
+   	#if BAR_WINICON_PATCH
+    updateicon(c);
+    #endif
 	updatetitle(c);
 	arrange(c->mon);
 	XMapWindow(dpy, c->win);

--- a/patch/swallow.c
+++ b/patch/swallow.c
@@ -37,9 +37,9 @@ swallow(Client *p, Client *c)
 	XChangeProperty(dpy, c->win, netatom[NetClientList], XA_WINDOW, 32, PropModeReplace,
 		(unsigned char *) &(p->win), 1);
 
-    #if BAR_WINICON_PATCH
-    updateicon(p);
-    #endif
+	#if BAR_WINICON_PATCH
+	updateicon(p);
+	#endif
 	updatetitle(p);
 	s = scanner ? c : p;
 	#if BAR_EWMHTAGS_PATCH
@@ -73,9 +73,9 @@ unswallow(Client *c)
 
 	/* unfullscreen the client */
 	setfullscreen(c, 0);
-    #if BAR_WINICON_PATCH
-    updateicon(c);
-    #endif
+	#if BAR_WINICON_PATCH
+	updateicon(c);
+	#endif
 	updatetitle(c);
 	arrange(c->mon);
 	XMapWindow(dpy, c->win);


### PR DESCRIPTION
Add swallow/window icon compatibility. Without this, after a client is swallowed the old icon (usually from the terminal emulator) is preserved. This is noticeable if you, say run `mpv` from a terminal emulator which is a common use case for the swallow patch.

This pull request fixes this by simply calling `updateicon` in `swallow` and `unswallow`, I have tested this and it works perfectly (unlike my last PR). I actually thought about just calling `updateicon` in `updatetitle` which would solve all of these issues but I'm not aware of any more issues so this will do I think.