### PR TITLE
Add toggletopbar patch

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -902,6 +902,9 @@ static const Key keys[] = {
 	{ MODKEY,                       XK_s,          rioresize,              {0} },
 	#endif // RIODRAW_PATCH
 	{ MODKEY,                       XK_b,          togglebar,              {0} },
+    #if TOGGLETOPBAR_PATCH
+    { MODKEY,                       XK_t,          toggletopbar,           {0} },
+    #endif // TOGGLETOPBAR_PATCH
 	#if TAB_PATCH
 	{ MODKEY|ControlMask,           XK_b,          tabmode,                {-1} },
 	#endif // TAB_PATCH

--- a/config.def.h
+++ b/config.def.h
@@ -903,7 +903,7 @@ static const Key keys[] = {
 	#endif // RIODRAW_PATCH
 	{ MODKEY,                       XK_b,          togglebar,              {0} },
     #if TOGGLETOPBAR_PATCH
-    { MODKEY,                       XK_t,          toggletopbar,           {0} },
+    { MODKEY|ShiftMask,             XK_b,          toggletopbar,           {0} },
     #endif // TOGGLETOPBAR_PATCH
 	#if TAB_PATCH
 	{ MODKEY|ControlMask,           XK_b,          tabmode,                {-1} },

--- a/dwm.c
+++ b/dwm.c
@@ -717,6 +717,9 @@ static pid_t spawncmd(const Arg *arg);
 static void tag(const Arg *arg);
 static void tagmon(const Arg *arg);
 static void togglebar(const Arg *arg);
+#if TOGGLETOPBAR_PATCH
+static void toggletopbar(const Arg *arg);
+#endif // TOGGLETOPBAR_PATCH
 static void togglefloating(const Arg *arg);
 static void toggletag(const Arg *arg);
 static void toggleview(const Arg *arg);
@@ -4151,6 +4154,17 @@ togglebar(const Arg *arg)
 	#endif // BAR_SYSTRAY_PATCH
 	arrange(selmon);
 }
+
+#if TOGGLETOPBAR_PATCH
+void
+toggletopbar(const Arg *arg)
+{
+    selmon->bar->topbar = !selmon->bar->topbar;
+	updatebarpos(selmon);
+	XMoveResizeWindow(dpy, selmon->bar->win, selmon->wx, selmon->bar->by, selmon->ww, selmon->bar->bh);
+	arrange(selmon);
+}
+#endif // TOGGLETOPBAR_PATCH
 
 void
 togglefloating(const Arg *arg)

--- a/patches.def.h
+++ b/patches.def.h
@@ -1250,6 +1250,19 @@
  */
 #define TAPRESIZE_PATCH 0
 
+/* This very simple patch adds a keybind (by default MODKEY + t) which changes
+ * the position of the bar during runtime.
+ *
+ * Because of the way the barpadding patch works, there needs to be a special
+ * patch for barpadding users as otherwise the bar will be positioned outside the screen.
+ *
+ * This patch should be applied on top of barpadding.
+ * The systray patch will also conflict, but only if barpadding is patched as well.
+ *
+ * https://dwm.suckless.org/patches/toggletopbar/
+ */
+#define TOGGLETOPBAR_PATCH 0
+
 /* This patch allows you to toggle fullscreen on and off using a single shortcut key.
  * https://github.com/bakkeby/patches/blob/master/dwm/dwm-togglefullscreen-6.2.diff
  */


### PR DESCRIPTION
Original patch [here](https://dwm.suckless.org/patches/toggletopbar/).

To support barpadding patch: [https://dwm.suckless.org/patches/toggletopbar/dwm-toggletopbar-barpadding-6.4.diff](https://dwm.suckless.org/patches/toggletopbar/dwm-toggletopbar-barpadding-6.4.diff) \[breaks systray patch\].