### PR TITLE
Use pkg-config to locate fribidi library's files

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -52,8 +52,8 @@ XRENDER = -lXrender
 #IMLIB2LIBS = -lImlib2
 
 # Uncomment for the bidi patch
-#BDINC = -I/usr/include/fribidi
-#BDLIBS = -lfribidi
+#BDINC = `pkg-config --cflags fribidi`
+#BDLIBS = `pkg-config --libs fribidi`
 
 # includes and libs
 INCS = -I${X11INC} -I${FREETYPEINC} ${YAJLINC} ${PANGOINC} ${BDINC}


### PR DESCRIPTION
When using something like NixOS or the Nix package manager that place packages' files in their own custom paths, directly specifying the path to the `fribidi` library makes the compilation fail. Using `pkg-config` fixes that. 