### PR TITLE
bugfix: checkinstall fails & dwm-msg not removed on uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,25 +47,27 @@ dist: clean
 
 install: all
 	mkdir -p ${DESTDIR}${PREFIX}/bin
-	cp -f dwm ${DESTDIR}${PREFIX}/bin
+	install -C -m 0755 dwm ${DESTDIR}${PREFIX}/bin/
 ifdef YAJLLIBS
-	cp -f dwm-msg ${DESTDIR}${PREFIX}/bin
+	install -C -m 0755 dwm-msg ${DESTDIR}${PREFIX}/bin/
 endif
 	#cp -f patch/dwmc ${DESTDIR}${PREFIX}/bin
-	chmod 755 ${DESTDIR}${PREFIX}/bin/dwm
+	#chmod 755 ${DESTDIR}${PREFIX}/bin/dwm
 ifdef YAJLLIBS
-	chmod 755 ${DESTDIR}${PREFIX}/bin/dwm-msg
+	#chmod 755 ${DESTDIR}${PREFIX}/bin/dwm-msg
 endif
-	mkdir -p ${DESTDIR}${MANPREFIX}/man1
+	#mkdir -p ${DESTDIR}${MANPREFIX}/man1
+	install -C -m 0755 dwm.1 -D ${DESTDIR}${MANPREFIX}/man1/dwm.1
 	sed "s/VERSION/${VERSION}/g" < dwm.1 > ${DESTDIR}${MANPREFIX}/man1/dwm.1
-	chmod 644 ${DESTDIR}${MANPREFIX}/man1/dwm.1
 	mkdir -p ${DESTDIR}${PREFIX}/share/xsessions
-	test -f ${DESTDIR}${PREFIX}/share/xsessions/dwm.desktop || cp -n dwm.desktop ${DESTDIR}${PREFIX}/share/xsessions
-	chmod 644 ${DESTDIR}${PREFIX}/share/xsessions/dwm.desktop
+	install -C -m 0644 dwm.desktop ${DESTDIR}${PREFIX}/share/xsessions
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/dwm\
 		${DESTDIR}${MANPREFIX}/man1/dwm.1\
 		${DESTDIR}${PREFIX}/share/xsessions/dwm.desktop
+ifdef YAJLLIBS
+	rm -f ${DESTDIR}${PREFIX}/bin/dwm-msg
+endif
 
 .PHONY: all clean dist install uninstall


### PR DESCRIPTION
this patch modifies the makefile to use the "install" command which behaves like cp,chmod,chown,mkdir all rolled into one. this simplifies the makefile & also makes it compatible with "checkinstall" on debian systems.