### PR TITLE
Fix when only one client in a tag and click it to hide it, then click…

### DIFF
--- a/patch/bar_wintitleactions.c
+++ b/patch/bar_wintitleactions.c
@@ -51,7 +51,7 @@ togglewin(const Arg *arg)
 	Client *c = (Client*)arg->v;
 	if (!c)
 		return;
-	if (c == selmon->sel)
+	if (!HIDDEN(c) && c == selmon->sel)
 		hide(c);
 	else {
 		if (HIDDEN(c))


### PR DESCRIPTION
Fix when only one client in a tag and click it to hide it, then click it one more time, the client will not show as expected.