### PR TITLE
Added color validation for BAR_STATUS2D_PATCH

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -622,6 +622,10 @@ static const BarRule barrules[] = {
 	#endif // BAR_FLEXWINTITLE_PATCH
 };
 
+#if BAR_STATUS2D_PATCH
+  #define BAR_STATUS2D_DEFAULT_COLOR "#000000"
+#endif
+
 /* layout(s) */
 static const float mfact     = 0.55; /* factor of master area size [0.05..0.95] */
 static const int nmaster     = 1;    /* number of clients in master area */

--- a/patch/bar_status2d.c
+++ b/patch/bar_status2d.c
@@ -77,6 +77,20 @@ click_status2d(Bar *bar, Arg *arg, BarArg *a)
 }
 #endif // BAR_STATUSCMD_PATCH
 
+static int is_valid_hex_color(const char* buf) {
+        if(buf == NULL) return 0;
+        int i = -1;
+        char c;
+        while((c = buf[++i])) {
+                if(i == 0 && c != '#') return 0;
+                int is_valid_code = (c >= '0' && c <= '9') ||
+                  (c >= 'A' && c <= 'F') ||
+                  (c >= 'a' && c <= 'f');
+                if(!is_valid_code && i > 0) return 0;
+        }
+        return i == 7;
+}
+
 int
 drawstatusbar(BarArg *a, char* stext)
 {
@@ -125,6 +139,7 @@ drawstatusbar(BarArg *a, char* stext)
 					}
 					memcpy(buf, (char*)text+i+1, 7);
 					buf[7] = '\0';
+                                        if(!is_valid_hex_color(buf)) memcpy(buf, BAR_STATUS2D_DEFAULT_COLOR, 8);
 					#if BAR_ALPHA_PATCH && BAR_STATUS2D_NO_ALPHA_PATCH
 					drw_clr_create(drw, &drw->scheme[ColFg], buf, 0xff);
 					#elif BAR_ALPHA_PATCH
@@ -142,6 +157,7 @@ drawstatusbar(BarArg *a, char* stext)
 					}
 					memcpy(buf, (char*)text+i+1, 7);
 					buf[7] = '\0';
+                                        if(!is_valid_hex_color(buf)) memcpy(buf, BAR_STATUS2D_DEFAULT_COLOR, 8);
 					#if BAR_ALPHA_PATCH && BAR_STATUS2D_NO_ALPHA_PATCH
 					drw_clr_create(drw, &drw->scheme[ColBg], buf, 0xff);
 					#elif BAR_ALPHA_PATCH


### PR DESCRIPTION
I noticed that dwm exits the process if the color used in BAR_STATS2D_PATCH prompt is wrong. This is pretty bad since the `stext` can be set by any program running on the computer with `xsetroot -name "..."`.

If the the prompt contains invalid color data such as `hello ^cinvalidcolor^ uwu`, `drw_clr_create` calls `die` which takes you back to your login manager.

This commit enables validation of the hex code before passing it into `drw_clr_create`. If the hex code is invalid, the hexcode is defaulted to `BAR_STATUS2D_DEFAULT_COLOR` which can be set in `confg.h`