### PR TITLE
Fix and improve BAR_WINTITLEACTIONS_PATCH

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1165,6 +1165,7 @@ static const Key keys[] = {
 	#endif // SHIFTSWAPTAGS_PATCH
 	#if BAR_WINTITLEACTIONS_PATCH
 	{ MODKEY|ControlMask,           XK_z,          showhideclient,         {0} },
+	{ MODKEY|ControlMask,           XK_s,          showall,                {0} },
 	#endif // BAR_WINTITLEACTIONS_PATCH
 	{ MODKEY|ShiftMask,             XK_c,          killclient,             {0} },
 	#if KILLUNSEL_PATCH

--- a/config.def.h
+++ b/config.def.h
@@ -1165,7 +1165,7 @@ static const Key keys[] = {
 	#endif // SHIFTSWAPTAGS_PATCH
 	#if BAR_WINTITLEACTIONS_PATCH
 	{ MODKEY|ControlMask,           XK_z,          showhideclient,         {0} },
-	{ MODKEY|ControlMask,           XK_s,          showall,                {0} },
+	{ MODKEY|ControlMask,           XK_s,          unhideall,              {0} },
 	#endif // BAR_WINTITLEACTIONS_PATCH
 	{ MODKEY|ShiftMask,             XK_c,          killclient,             {0} },
 	#if KILLUNSEL_PATCH

--- a/dwm.c
+++ b/dwm.c
@@ -3033,7 +3033,12 @@ quit(const Arg *arg)
 	unsigned int n = 0;
 
 	for (m = mons; m; m = m->next)
-		for (c = m->clients; c; c = c->next, n++);
+		for (c = m->clients; c; c = c->next)
+		#if RESTARTSIG_PATCH && BAR_WINTITLEACTIONS_PATCH
+			if (c && HIDDEN(c)) show(c);
+		#else
+			++n;
+		#endif // RESTARTSIG_PATCH && BAR_WINTITLEACTIONS_PATCH
 
 	#if RESTARTSIG_PATCH
 	if (restart || n <= quit_empty_window_count)
@@ -3045,6 +3050,11 @@ quit(const Arg *arg)
 		fprintf(stderr, "[dwm] not exiting (n=%d)\n", n);
 
 	#else // !ONLYQUITONEMPTY_PATCH
+	#if RESTARTSIG_PATCH && BAR_WINTITLEACTIONS_PATCH
+	for (Monitor *m = mons; m; m = m->next)
+		for (Client *c = m->clients; c; c = c->next)
+			if (c && HIDDEN(c)) show(c);
+	#endif // RESTARTSIG_PATCH && BAR_WINTITLEACTIONS_PATCH
 	running = 0;
 	#endif // ONLYQUITONEMPTY_PATCH
 }

--- a/dwm.c
+++ b/dwm.c
@@ -3033,12 +3033,7 @@ quit(const Arg *arg)
 	unsigned int n = 0;
 
 	for (m = mons; m; m = m->next)
-		for (c = m->clients; c; c = c->next)
-		#if RESTARTSIG_PATCH && BAR_WINTITLEACTIONS_PATCH
-			if (c && HIDDEN(c)) show(c);
-		#else
-			++n;
-		#endif // RESTARTSIG_PATCH && BAR_WINTITLEACTIONS_PATCH
+		for (c = m->clients; c; c = c->next, n++);
 
 	#if RESTARTSIG_PATCH
 	if (restart || n <= quit_empty_window_count)
@@ -3050,11 +3045,6 @@ quit(const Arg *arg)
 		fprintf(stderr, "[dwm] not exiting (n=%d)\n", n);
 
 	#else // !ONLYQUITONEMPTY_PATCH
-	#if RESTARTSIG_PATCH && BAR_WINTITLEACTIONS_PATCH
-	for (Monitor *m = mons; m; m = m->next)
-		for (Client *c = m->clients; c; c = c->next)
-			if (c && HIDDEN(c)) show(c);
-	#endif // RESTARTSIG_PATCH && BAR_WINTITLEACTIONS_PATCH
 	running = 0;
 	#endif // ONLYQUITONEMPTY_PATCH
 }
@@ -4582,7 +4572,8 @@ unmanage(Client *c, int destroyed)
 		XSelectInput(dpy, c->win, NoEventMask);
 		XConfigureWindow(dpy, c->win, CWBorderWidth, &wc); /* restore border */
 		XUngrabButton(dpy, AnyButton, AnyModifier, c->win);
-		setclientstate(c, WithdrawnState);
+		if (!HIDDEN(c))
+			setclientstate(c, WithdrawnState);
 		XSync(dpy, False);
 		XSetErrorHandler(xerror);
 		XUngrabServer(dpy);

--- a/patch/bar_wintitleactions.c
+++ b/patch/bar_wintitleactions.c
@@ -93,17 +93,14 @@ showhideclient(const Arg *arg)
 }
 
 void
-showall(const Arg *arg)
+unhideall(const Arg *arg)
 {
 	Client *c = NULL;
 	for (c = selmon->clients; c; c = c->next) {
-		if (ISVISIBLE(c))
-			show(c);
+		if (ISVISIBLE(c)) {
+			XMapWindow(dpy, c->win);
+			setclientstate(c, NormalState);
+		}
 	}
-	if (!selmon->sel) {
-		for (c = selmon->clients; c && !ISVISIBLE(c); c = c->next);
-		if (c)
-			focus(c);
-	}
-	restack(selmon);
+	arrange(selmon);
 }

--- a/patch/bar_wintitleactions.c
+++ b/patch/bar_wintitleactions.c
@@ -92,3 +92,18 @@ showhideclient(const Arg *arg)
 	}
 }
 
+void
+showall(const Arg *arg)
+{
+	Client *c = NULL;
+	for (c = selmon->clients; c; c = c->next) {
+		if (ISVISIBLE(c))
+			show(c);
+	}
+	if (!selmon->sel) {
+		for (c = selmon->clients; c && !ISVISIBLE(c); c = c->next);
+		if (c)
+			focus(c);
+	}
+	restack(selmon);
+}

--- a/patch/bar_wintitleactions.h
+++ b/patch/bar_wintitleactions.h
@@ -3,4 +3,5 @@ static void show(Client *c);
 static void togglewin(const Arg *arg);
 static Client * prevtiled(Client *c);
 static void showhideclient(const Arg *arg);
+static void showall(const Arg *arg);
 

--- a/patch/bar_wintitleactions.h
+++ b/patch/bar_wintitleactions.h
@@ -3,5 +3,5 @@ static void show(Client *c);
 static void togglewin(const Arg *arg);
 static Client * prevtiled(Client *c);
 static void showhideclient(const Arg *arg);
-static void showall(const Arg *arg);
+static void unhideall(const Arg *arg);
 


### PR DESCRIPTION
The first thing that corrects this PR is the loss of hidden clients after rebooting with a RESTARTSIG_PATCH.

Second, this is the addition of the opportunity to show all the hidden clients using a combination of keys, which is sometimes useful.