### PR TITLE
patch/layout_tile.c: round client width after multiplying by mfact

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -22,6 +22,7 @@
  */
 #include <errno.h>
 #include <locale.h>
+#include <math.h>
 #include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -1946,7 +1947,7 @@ void
 drawbar(Monitor *m)
 {
 	Bar *bar;
-	
+
 	#if !BAR_FLEXWINTITLE_PATCH
 	if (m->showbar)
 	#endif // BAR_FLEXWINTITLE_PATCH
@@ -5508,4 +5509,3 @@ main(int argc, char *argv[])
 	#endif // RESTARTSIG_PATCH
 	return EXIT_SUCCESS;
 }
-

--- a/patch/layout_tile.c
+++ b/patch/layout_tile.c
@@ -27,8 +27,8 @@ tile(Monitor *m)
 	sw = mw = m->ww - 2*ov;
 
 	if (m->nmaster && n > m->nmaster) {
-		sw = (mw - iv) * (1 - m->mfact);
-		mw = (mw - iv) * m->mfact;
+		sw = round((mw - iv) * (1 - m->mfact));
+		mw = round((mw - iv) * m->mfact);
 		sx = mx + mw + iv;
 	}
 	#else
@@ -38,8 +38,8 @@ tile(Monitor *m)
 	sw = mw = m->ww;
 
 	if (m->nmaster && n > m->nmaster) {
-		sw = mw * (1 - m->mfact);
-		mw = mw * m->mfact;
+		sw = round(mw * (1 - m->mfact));
+		mw = round(mw * m->mfact);
 		sx = mx + mw;
 	}
 	#endif // VANITYGAPS_PATCH
@@ -71,4 +71,3 @@ tile(Monitor *m)
 			#endif
 		}
 }
-


### PR DESCRIPTION
This PR intends to fix off-by-one errors that appear when using the default tiled layout, resulting in clients not reaching their full width:

<img width="204" height="136" alt="off-by-one" src="https://github.com/user-attachments/assets/64430c72-aad3-4850-b41c-47b55f8c0d50" />

I see that upstream doesn't multiply by mfact when calculating client width, so the problem doesn't exist there.

I also noticed that there are other instances of non-rounded multiplication by mfact throughout different patches, which I believe also result in this problem. If my solution is acceptable, I'll extend it to those instances as well. 